### PR TITLE
Wordwrap for table headers

### DIFF
--- a/seeker/templates/advanced_seeker/results.html
+++ b/seeker/templates/advanced_seeker/results.html
@@ -22,7 +22,11 @@
                             </th>
                         {% endif %}
                         {% for col in display_columns %}
-                            {{ col.header }}
+                            {% if use_wordwrap_header %}
+                                {% seeker_column_header col results %}
+                            {% else %}
+                                {{ col.header }}
+                            {% endif %}
                         {% endfor %}
                     {% endblock table-headers %}
                     {% block post-table-headers %}{% endblock post-table-headers %}

--- a/seeker/templatetags/seeker.py
+++ b/seeker/templatetags/seeker.py
@@ -64,6 +64,9 @@ def advanced_seeker_facet(facet, **params):
 def seeker_column(column, result, **kwargs):
     return column.render(result, **kwargs)
 
+@register.simple_tag
+def seeker_column_header(column, results=None):
+    return column.header(results)
 
 @register.simple_tag
 def seeker_score(result, max_score=None, template='seeker/score.html'):


### PR DESCRIPTION
Updated AdvancedSeeker with use_wordwrap_header to add capability of wordwrapping to the table headers if headers are longer than the data.